### PR TITLE
Fix conversion of subTypes to allOf and optional URL scheme

### DIFF
--- a/index.js
+++ b/index.js
@@ -480,7 +480,9 @@ function transformAllModels(models) {
         var allOf = (childModel.allOf || []).concat({
           $ref: '#/definitions/' + parent
         }).concat(clone(childModel));
-        for (var member in childModel) delete childModel[member];
+        for (var member in childModel) {
+          delete childModel[member];
+        }
         childModel.allOf = allOf;
       }
     });

--- a/index.js
+++ b/index.js
@@ -477,9 +477,11 @@ function transformAllModels(models) {
       var childModel = modelsClone[childId];
 
       if (childModel) {
-        childModel.allOf = (childModel.allOf || []).concat({
+        var allOf = (childModel.allOf || []).concat({
           $ref: '#/definitions/' + parent
-        });
+        }).concat(clone(childModel));
+        for (var member in childModel) delete childModel[member];
+        childModel.allOf = allOf;
       }
     });
   });

--- a/index.js
+++ b/index.js
@@ -154,7 +154,9 @@ function assignPathComponents(basePath, result) {
   var url = urlParse(basePath);
   result.host = url.host;
   result.basePath = url.path;
-  result.schemes = [url.protocol.substr(0, url.protocol.length - 1)];
+  if (url.protocol) {
+    result.schemes = [url.protocol.substr(0, url.protocol.length - 1)];
+  }
 }
 
 /*

--- a/test/output/petstore.json
+++ b/test/output/petstore.json
@@ -667,17 +667,19 @@
             "discriminator": "type"
         },
         "Cat": {
-            "required": [
-                "likesMilk"
-            ],
-            "properties": {
-                "likesMilk": {
-                    "type": "boolean"
-                }
-            },
             "allOf": [
                 {
                     "$ref": "#/definitions/Animal"
+                },
+                {
+                    "required": [
+                        "likesMilk"
+                    ],
+                    "properties": {
+                        "likesMilk": {
+                            "type": "boolean"
+                        }
+                    }
                 }
             ]
         },


### PR DESCRIPTION
We tried to use this together with swagger-codegen, but ran into some trouble regarding allOf. The spec has some example of how childs should look which we fixed the converter to align with.