### PR TITLE
Fix 'default' value conversion, in case if 'type' is 'string'

### DIFF
--- a/index.js
+++ b/index.js
@@ -206,16 +206,19 @@ function processDataType(field, fixRef) {
   }
 
   if (field.minimum) {
-    field.minimum = fixValueType(field.minimum);
+    field.minimum = fixNonStringValue(field.minimum);
   }
 
   if (field.maximum) {
-    field.maximum = fixValueType(field.maximum);
+    field.maximum = fixNonStringValue(field.maximum);
   }
 
   if (field.defaultValue) {
-    field.default = fixValueType(field.defaultValue);
+    field.default = field.defaultValue;
     delete field.defaultValue;
+    if (field.type && field.type !== 'string') {
+      field.default = fixNonStringValue(field.default);
+    }
   }
 
   return field;
@@ -542,7 +545,7 @@ function extend(source, destination) {
  * @param value {*} - value to convert
  * @returns {*} - transformed modles object
 */
-function fixValueType(value) {
+function fixNonStringValue(value) {
   if (typeof value !== 'string') {
     return value;
   }

--- a/test/input/complex-parameters/index.json
+++ b/test/input/complex-parameters/index.json
@@ -29,6 +29,26 @@
               "message": "POST successful"
             }
           ]
+        },
+        {
+          "method": "GET",
+          "summary": "GET from root",
+          "parameters": [
+            {
+              "name": "documentId",
+              "paramType": "query",
+              "description": "The document ID",
+              "required": false,
+              "type": "string",
+              "defaultValue": "latest"
+            }
+          ],
+          "responseMessages": [
+            {
+              "code": 200,
+              "message": "GET successful"
+            }
+          ]
         }
       ]
     }

--- a/test/output/complex-parameters.json
+++ b/test/output/complex-parameters.json
@@ -28,6 +28,25 @@
             "description": "POST successful"
           }
         }
+      },
+      "get": {
+        "description": "",
+        "summary": "GET from root",
+        "parameters": [
+          {
+            "description": "The document ID",
+            "in": "query",
+            "name": "documentId",
+            "required": false,
+            "type": "string",
+            "default": "latest"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "GET successful"
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
I introduce this mistake in #24 PR.
Rename function to prevent future misuse 