### PR TITLE
I had to use a JSON.stringify function call to get a valid json document

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ var apiDeclarations = [
 
 var swagger2Document = convert(resourceListing, apiDeclarations);
 
-console.log(swagger2Document);
+console.log(JSON.stringify(swagger2Document));
 ```
 
 ##### In browser


### PR DESCRIPTION
I had to use a JSON.stringify function call to get a valid json document from the conversion.  Otherwise, I had a bunch of places in the document that just had '[Object]' instead of the full json representation of the
objects.