### PR TITLE
Allow vendor extension attributes for parameters.

### DIFF
--- a/index.js
+++ b/index.js
@@ -556,6 +556,12 @@ prototype.buildParameter = function(oldParameter) {
     required: fixNonStringValue(oldParameter.required)
   });
 
+  Object.keys(oldParameter).forEach(function(property) {
+    if (property.match(/^X-/i) !== null) {
+      parameter[property] = oldParameter[property];
+    }
+  });
+
   if (parameter.in === 'form') {
     parameter.in = 'formData';
   }

--- a/test/input/fixable/pets.json
+++ b/test/input/fixable/pets.json
@@ -13,6 +13,7 @@
             {
               "description": "Body parameter with missing name",
               "paramType": "body",
+              "x-whatever": "foo",
               "type": "BrokenModel"
             },
             {

--- a/test/output/fixable.json
+++ b/test/output/fixable.json
@@ -25,6 +25,7 @@
                     {
                         "in": "body",
                         "description": "Body parameter with missing name",
+                        "x-whatever": "foo",
                         "schema": {
                             "$ref": "#/definitions/BrokenModel"
                         },


### PR DESCRIPTION
Swagger 1.2 does not support vendor extensions but Swagger 2.0 does.

Some people have Swagger 1.2 specifications that implement vendor
extensions for parameter attributes. Then it would be fine to allow
converting these specifications automatically.