### PR TITLE
Allow specify tags.

### DIFF
--- a/index.js
+++ b/index.js
@@ -498,12 +498,11 @@ prototype.buildOperation = function(oldOperation, operationDefaults) {
     parameters.push(this.buildParameter(oldParameter));
   });
 
+  /*
+   * Merges the tags from the resourceListing and the ones specified in the apiDeclaration.
+   */
   var tags = (operationDefaults.tags || []).concat(oldOperation.tags || []);
-
-  tags = tags.filter(function(e, i, arr) {
-    var element = arr.lastIndexOf(e) === i;
-    return element;
-  });
+  tags = removeDuplicates(tags);
 
   return extend({}, operationDefaults, {
     operationId: oldOperation.nickname,
@@ -909,4 +908,16 @@ function fixNonStringValue(value, skipError) {
 
     throw new SwaggerConverterError('incorect property value: ' + e.message);
   }
+}
+
+/*
+ * Remove duplicates of an array
+ * @params collection {array}
+ * @returns {array} - collection without duplicates
+ */
+
+function removeDuplicates(collection) {
+  return collection.filter(function(e, i, arr) {
+    return arr.lastIndexOf(e) === i;
+  });
 }

--- a/index.js
+++ b/index.js
@@ -498,10 +498,18 @@ prototype.buildOperation = function(oldOperation, operationDefaults) {
     parameters.push(this.buildParameter(oldParameter));
   });
 
+  var tags = (operationDefaults.tags || []).concat(oldOperation.tags || []);
+
+  tags = tags.filter(function(e, i, arr) {
+    var element = arr.lastIndexOf(e) === i;
+    return element;
+  });
+
   return extend({}, operationDefaults, {
     operationId: oldOperation.nickname,
     summary: oldOperation.summary,
     description: oldOperation.description || oldOperation.notes,
+    tags: undefinedIfEmpty(tags),
     deprecated: fixNonStringValue(oldOperation.deprecated),
     produces: oldOperation.produces,
     consumes: oldOperation.consumes,

--- a/test/input/embedded/index.json
+++ b/test/input/embedded/index.json
@@ -9,6 +9,7 @@
         {
           "method": "GET",
           "summary": "",
+          "tags": ["pets"],
           "responseMessages": [
             {
               "code": 200,

--- a/test/input/fixable/pets.json
+++ b/test/input/fixable/pets.json
@@ -9,6 +9,7 @@
         {
           "method": "GET",
           "summary": "",
+          "tags": ["pets"],
           "parameters": [
             {
               "description": "Body parameter with missing name",

--- a/test/input/petstore/user.json
+++ b/test/input/petstore/user.json
@@ -14,6 +14,7 @@
           "method": "POST",
           "summary": "Creates list of users with given input array",
           "notes": "",
+          "tags": ["otherTag"],
           "type": "void",
           "nickname": "createUsersWithArrayInput",
           "authorizations": {

--- a/test/output/embedded.json
+++ b/test/output/embedded.json
@@ -12,6 +12,7 @@
     "paths": {
         "/pets": {
             "get": {
+                "tags": ["pets"],
                 "responses": {
                     "200": {
                         "description": "Return all pets"

--- a/test/output/petstore.json
+++ b/test/output/petstore.json
@@ -423,7 +423,8 @@
                 "summary": "Creates list of users with given input array",
                 "operationId": "createUsersWithArrayInput",
                 "tags": [
-                    "user"
+                    "user",
+                    "otherTag"
                 ],
                 "produces": [
                     "application/json"


### PR DESCRIPTION
Swagger 1.2 does not support tags, but swagger-converter uses the
apiDeclaration to define tags on the generated swagger spec 2.0.

This commit merges the tags from the resourceListing and the ones specified in the apiDeclaration.