### PR TITLE
Produce better stack traces

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ var SwaggerConverter = module.exports = {};
  */
 function SwaggerConverterError(message) {
   this.message = message;
-  this.stack = Error().stack;
+  this.stack = (new Error(message)).stack;
 }
 SwaggerConverterError.prototype = Object.create(Error.prototype);
 SwaggerConverterError.prototype.name = 'SwaggerConverterError';


### PR DESCRIPTION
Instead of this:
```
Error
    at Error (native)
    at Error.SwaggerConverterError (/home/ivang/dev/api-models/node_modules/swagger-converter/index.js:38:16)
    at null.<anonymous> (/home/ivang/dev/api-models/node_modules/swagger-converter/index.js:261:13)
```
Produce this:
```
Error: Resources can not override each other basePaths
    at Error.SwaggerConverterError (/home/ivang/dev/api-models/node_modules/swagger-converter/index.js:38:17)
    at null.<anonymous> (/home/ivang/dev/api-models/node_modules/swagger-converter/index.js:261:13)
```