### PR TITLE
add preserveOrder option to avoid sorting keys

### DIFF
--- a/index.js
+++ b/index.js
@@ -904,13 +904,17 @@ prototype.forEach = function (collection, iteratee) {
   if (Array.isArray(collection)) {
     collection.forEach(iteratee);
   } else {
-    //In some cases order of iteration influence order of arrays in output.
-    //To have stable result of convertion, keys need to be sorted.
-    Object.keys(collection)
-      .sort()
-      .forEach(function (key) {
-        iteratee(collection[key], key);
-      });
+    var keys = Object.keys(collection);
+
+    if (!this.options.preserveOrder) {
+      //In some cases order of iteration influence order of arrays in output.
+      //To have stable result of convertion, keys need to be sorted.
+      keys.sort();
+    }
+
+    keys.forEach(function (key) {
+      iteratee(collection[key], key);
+    });
   }
 };
 


### PR DESCRIPTION
Currently swagger-converter sorts all keys to make sure the output is
deterministic. In some cases, the order of properties matters.

For instance a model that understandably mentions id and name first. For
code generation and example generation it helps to keep these properties
first.

`preserveOrder: true` may help in these cases.
