### PR TITLE
Fix EOL mismatch resulting in false negative test result

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -139,13 +139,13 @@ function testInput(input) {
 
     it('output should produce the same output as output file', () => {
       const outputFilePath = path.join(outputPath, input.output);
-      const fileContent = JSON.stringify(sortObject(converted), null, 2) + '\n';
+      const fileContent = sortObject(converted);
 
       if (process.env.WRITE_CONVERTED) {
-        fs.writeFileSync(outputFilePath, fileContent);
+        fs.writeFileSync(outputFilePath, JSON.stringify(fileContent, null, 2) + '\n');
       }
 
-      const outputFile = fs.readFileSync(outputFilePath, 'utf-8');
+      const outputFile = JSON.parse(fs.readFileSync(outputFilePath, 'utf-8'));
       expect(fileContent).to.deep.equal(outputFile);
     });
   });


### PR DESCRIPTION
The tests currently fail on Windows because the expected-output-files use Unix-style line endings.
This can be circumvented by comparing using the parsed expected-output instead of the stringified actual-output.

For bonus points: this enables Chai to produce much more detailed diffs when things go wrong :)